### PR TITLE
spec_helper.rb: Add a require for 'pathname'

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ begin
 rescue LoadError; end
 
 require 'dry-logic'
+require 'pathname'
 
 SPEC_ROOT = Pathname(__dir__)
 


### PR DESCRIPTION
I noticed that when I just type `rspec` or `rake` in a shell to run the tests of this gem, it fails because `spec_helper.rb` uses `Pathname`, which is undefined.  This just adds the line `require 'pathname'` to fix that.  Thanks!